### PR TITLE
Added feedback and user input functionality via a mini buffer

### DIFF
--- a/src/h5forest/h5_forest.py
+++ b/src/h5forest/h5_forest.py
@@ -144,7 +144,14 @@ class H5Forest:
         self.metadata_content = None
         self.attributes_content = None
         self.values_content = None
+        self.mini_buffer_content = None
         self._init_text_areas()
+
+        # Set up the mini buffer
+        self.mini_buffer = Frame(
+            self.mini_buffer_content,
+            height=3,
+        )
 
         # Set up the list of hotkeys and leaders for the UI
         # These will always be displayed unless the user is in a leader mode
@@ -279,6 +286,12 @@ class H5Forest:
 
             # If we have a dataset just do nothing
             if node.is_dataset:
+                self.print(f"{node.path} is not a Group")
+                return
+
+            # If the node has no children, do nothing
+            if not node.has_children:
+                self.print(f"{node.path} has no children")
                 return
 
             # If the node is already open, close it
@@ -307,6 +320,11 @@ class H5Forest:
             """
             # Get the node under the cursor
             node = self.tree.get_current_node(self.current_row)
+
+            # Exit if the node is not a Dataset
+            if node.is_group:
+                self.print(f"{node.path} is not a Dataset")
+                return
 
             # Get the value string
             text = node.get_value_text()
@@ -385,6 +403,13 @@ class H5Forest:
             read_only=True,
             scrollbar=True,
             focusable=False,
+        )
+
+        self.mini_buffer_content = TextArea(
+            text="Welcome to h5forest!",
+            scrollbar=False,
+            focusable=True,
+            read_only=False,
         )
 
     def set_cursor_position(self, text, new_cursor_pos):
@@ -478,6 +503,7 @@ class H5Forest:
                 ),
             ]
         )
+        self.hotkeys_frame = Frame(self.hotkeys_panel, height=3)
 
         # Layout using split views
         self.layout = Layout(
@@ -499,10 +525,16 @@ class H5Forest:
                             ),
                         ]
                     ),
-                    self.hotkeys_panel,
+                    self.hotkeys_frame,
+                    self.mini_buffer,
                 ]
             )
         )
+
+    def print(self, *args):
+        """Print a single line to the mini buffer."""
+        self.mini_buffer_content.text = " ".join(args)
+        get_app().invalidate()
 
 
 def main():

--- a/src/h5forest/node.py
+++ b/src/h5forest/node.py
@@ -311,16 +311,22 @@ class Node:
             self._attr_text = self._get_attr_text()
         return self._attr_text
 
-    def get_value_text(self):
+    def get_value_text(self, start_index=None, end_index=None):
         """
-        Return the value text for the node.
+        Return the value text for the node (optionally in a range).
 
         If this node is a Group then an empty string is returned and showing
-        the value frame won't be triggered.
+        the value frame won't be triggered. Note that this should be handled
+        outside but is included for safety.
 
-        If the Dataset is small enough we can just read everything and display
-        it. If the dataset is too large we will only show a truncated view
-        (first 100 elements or what will fit in the TextArea).
+        When no range is specified this method will try to limit to a sensible
+        output size if necessary. If the Dataset is small enough we can
+        just read everything and display it. If the dataset is too large
+        we will only show a truncated view (first 100 elements or what will
+        fit in the TextArea).
+
+        When a range is stated that range of values will be read in and
+        displayed.
 
         Returns:
             str:
@@ -335,8 +341,16 @@ class Node:
                 # How many values roughly can we show maximally?
                 max_count = 1000
 
+                # If a range has been given follow that
+                if start_index is not None:
+                    data_subset = dataset[start_index:end_index]
+                    truncated = (
+                        f"\n\nShowing {len(data_subset)}/"
+                        f"{dataset.size} elements ({start_index}-{end_index})."
+                    )
+
                 # If the dataset is small enough we can just read everything
-                if dataset.size < max_count:
+                elif dataset.size < max_count:
                     data_subset = dataset[...]
                     truncated = ""
 


### PR DESCRIPTION
This PR adds a mini buffer which can accept user input.

- A mini buffer and input buffer have been added to the bottom of the UI (the latter is only shown when it contains text.
- A `print` and `input` method have been added to display and ingest text respectively.
- An option to display a range of `Dataset` values defined by indices has been added using this new functionality.
- User feedback is now given in the mini buffer if undefined behaviour is requested (e.g. displaying values of a Group, uncollapsing a Dataset, uncollapsing a Group with no children, etc.)