### PR TITLE
Simplify the dataset operations for multi-axis datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,77 @@ dependencies = [
 
 [project.scripts]
 h5forest = "h5forest.h5_forest:main"
+
+# Configure the linter and formatter
+[tool.ruff]
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    ".DS_Store",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "*__init__.py"  # ignore all init files
+]
+
+# PEP-8 line length
+line-length = 79
+indent-width = 4
+
+
+# Assume Python 3.8 by default regardless
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and pycodestyle (`E`)  codes by default.
+select = ["F", "E", "W"]
+ignore = [
+       "E402",  # "module level import not at top of file" (isolate C imports in case python alternatives exist)
+       "F811",  # "redefinition of unused name from line N" (breaks quantity objects)
+       ]
+
+# Sort imports alphabetically
+extend-select = ["I"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/src/h5forest/bindings/bindings.py
+++ b/src/h5forest/bindings/bindings.py
@@ -5,6 +5,7 @@ always active and are not dependent on any leader key. The functions in this
 module should not be called directly, but are intended to be used by the main
 application.
 """
+
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.widgets import Label
 

--- a/src/h5forest/bindings/dataset_bindings.py
+++ b/src/h5forest/bindings/dataset_bindings.py
@@ -7,6 +7,7 @@ values, getting the minimum and maximum, mean, and standard deviation.
 The functions in this module should not be called directly, but are
 intended to be used by the main application.
 """
+
 import threading
 
 from prompt_toolkit.filters import Condition

--- a/src/h5forest/bindings/hist_bindings.py
+++ b/src/h5forest/bindings/hist_bindings.py
@@ -3,6 +3,7 @@
 This module contains the function that defines the bindings for the histogram
 and attaches them to the application. It should not be used directly.
 """
+
 import threading
 
 from prompt_toolkit.document import Document

--- a/src/h5forest/bindings/jump_bindings.py
+++ b/src/h5forest/bindings/jump_bindings.py
@@ -7,6 +7,7 @@ This module defines the functions for binding jump mode events to functions.
 This should not be used directly, but instead provides the functions for the
 application.
 """
+
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.layout import VSplit
 from prompt_toolkit.widgets import Label

--- a/src/h5forest/bindings/plot_bindings.py
+++ b/src/h5forest/bindings/plot_bindings.py
@@ -1,8 +1,10 @@
 """This module contains the keybindings for the plotting mode.
 
-The functions in this module are used to define the keybindings for the plotting
-mode and attach them to the application. It should not be used directly.
+The functions in this module are used to define the keybindings for the
+plotting mode and attach them to the application. It should not be used
+directly.
 """
+
 import threading
 
 from prompt_toolkit.document import Document

--- a/src/h5forest/bindings/tree_bindings.py
+++ b/src/h5forest/bindings/tree_bindings.py
@@ -4,10 +4,11 @@ This module contains the keybinding functions for the file tree. The functions
 in this module should not be called directly, but are intended to be used by
 the application.
 """
+
+from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.layout import ConditionalContainer
 from prompt_toolkit.widgets import Label
-from prompt_toolkit.document import Document
 
 
 def _init_tree_bindings(app):

--- a/src/h5forest/bindings/window_bindings.py
+++ b/src/h5forest/bindings/window_bindings.py
@@ -4,6 +4,7 @@ This module contains the functions for binding window events to functions. This
 should not be used directly, but instead provides the functions for the
 application.
 """
+
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.layout.containers import ConditionalContainer, VSplit
 from prompt_toolkit.widgets import Label

--- a/src/h5forest/h5_forest.py
+++ b/src/h5forest/h5_forest.py
@@ -496,7 +496,9 @@ class H5Forest:
             self.tree_content,
             title="HDF5 File Tree",
         )
-        self.metadata_frame = Frame(self.metadata_content, title="Metadata", height=10)
+        self.metadata_frame = Frame(
+            self.metadata_content, title="Metadata", height=10
+        )
         self.attrs_frame = Frame(self.attributes_content, title="Attributes")
         self.values_frame = Frame(
             self.values_content,
@@ -568,7 +570,8 @@ class H5Forest:
         self.plot_frame = ConditionalContainer(
             Frame(self.plot_content, title="Plotting", height=10),
             filter=Condition(
-                lambda: self.flag_plotting_mode or len(self.density_plotter) > 0
+                lambda: self.flag_plotting_mode
+                or len(self.density_plotter) > 0
             ),
         )
 

--- a/src/h5forest/node.py
+++ b/src/h5forest/node.py
@@ -158,6 +158,14 @@ class Node:
             self.compression_opts = obj.compression_opts
             self.chunks = obj.chunks if obj.chunks is not None else obj.shape
             self.is_chunked = obj.chunks != obj.shape
+            self.nchunks = (
+                1
+                if not self.is_chunked
+                else (
+                    int(np.ceil(s / c))
+                    for s, c in zip(self.shape, self.chunks)
+                )
+            )
             self.fillvalue = obj.fillvalue
             self.nbytes = obj.nbytes
             self.ndim = obj.ndim
@@ -396,10 +404,11 @@ class Node:
         """
         Return the minimum and maximum values of the dataset.
 
-        To limit the memory load this will use the chunks recorded in the
-        dataset to read in the data in manageable chunks and compute the
-        minimum and maximum values on the fly. If chunks == shape then
-        they are calculated on the whole Dataset.
+        This will return the global minimum and maximum values of the dataset.
+
+        If the dataset is chunked we will use them to limit the memory load
+        and read in the data in manageable chunks and compute the
+        minimum and maximum values on the fly.
 
         Returns:
             tuple:
@@ -416,109 +425,49 @@ class Node:
                     arr = dataset[:]
                     return arr.min(), arr.max()
 
-                # OK, we have chunks. Now we need to have slightly different
-                # behaviours based on dimensions
+                # OK, we have chunks, lets use them to avoid loading too
+                # much. behaviours
+                # based on dimensions
 
                 # For 1D arrays we can just loop getting the min and max.
-                if self.ndim == 1:
-                    # Define the initial min and max
-                    min_val = np.inf
-                    max_val = -np.inf
+                # Define the initial min and max
+                min_val = np.inf
+                max_val = -np.inf
 
-                    # Compute the number of chunks in each dimension
-                    n_chunks = int(self.shape[0] / self.chunks[0])
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="Min/Max"
-                    ) as pb:
-                        for chunk_index in range(n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                [
-                                    slice(
-                                        chunk_index * self.chunks[0],
-                                        min(
-                                            (chunk_index + 1) * self.chunks[0],
-                                            self.shape[0],
-                                        ),
-                                    ),
-                                ]
+                # Loop over all possible chunks
+                with ProgressBar(total=self.size, description="Min/Max") as pb:
+                    for chunk_index in np.ndindex(*self.n_chunks):
+                        # Get the current slice for each dimension
+                        slices = tuple(
+                            slice(
+                                c_idx * c_size,
+                                min((c_idx + 1) * c_size, s),
                             )
-
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
-
-                            # Get the minimum and maximum for the final
-                            # dimension
-                            min_val = np.min((min_val, np.min(chunk_data)))
-                            max_val = np.max((max_val, np.max(chunk_data)))
-
-                            pb.advance(step=chunk_data.size)
-
-                    return min_val, max_val
-
-                # Otherwise we get the minimum and maximum for the final
-                # dimension
-                else:
-                    # Define initial min and max
-                    min_val = np.full(self.shape[-1], np.inf)
-                    max_val = np.full(self.shape[-1], -np.inf)
-
-                    # Compute the number of chunks in each dimension
-                    n_chunks = [
-                        int(np.ceil(s / c))
-                        for s, c in zip(self.shape, self.chunks)
-                    ]
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="Min/Max"
-                    ) as pb:
-                        for chunk_index in np.ndindex(*n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                slice(
-                                    c_idx * c_size,
-                                    min((c_idx + 1) * c_size, s),
-                                )
-                                for c_idx, c_size, s in zip(
-                                    chunk_index, self.chunks, self.shape
-                                )
+                            for c_idx, c_size, s in zip(
+                                chunk_index, self.chunks, self.shape
                             )
+                        )
 
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
+                        # Read the chunk data
+                        chunk_data = dataset[slices]
 
-                            # Get the minimum and maximum for the final
-                            # dimension
-                            min_val = np.minimum(
-                                min_val,
-                                np.min(
-                                    chunk_data,
-                                    axis=tuple(range(self.ndim - 1)),
-                                ),
-                            )
-                            max_val = np.maximum(
-                                max_val,
-                                np.max(
-                                    chunk_data,
-                                    axis=tuple(range(self.ndim - 1)),
-                                ),
-                            )
+                        # Get the minimum and maximum
+                        min_val = np.min((min_val, np.min(chunk_data)))
+                        max_val = np.max((max_val, np.max(chunk_data)))
 
-                            pb.advance(step=chunk_data.size)
+                        pb.advance(step=chunk_data.size)
 
-                    return min_val, max_val
+                return min_val, max_val
 
     def get_mean(self):
         """
         Return the mean of the dataset values.
 
-        To limit the memory load this will use the chunks recorded in the
-        dataset to read in the data in manageable chunks and compute the
-        mean value on the fly. If chunks == shape then
-        the mean is calculated on the whole Dataset.
+        This will calculate the global mean of the dataset, ignoring any axes.
+
+        If the dataset is chunked we will use them to limit the memory load
+        and read in the data in manageable chunks and compute the mean value
+        on the fly.
 
         Returns:
             float:
@@ -533,101 +482,52 @@ class Node:
                 # If chunks and shape are equal just get the min and max
                 if not self.is_chunked:
                     arr = dataset[:]
-                    return arr.mean(axis=0)
+                    return arr.mean()
 
-                # OK, we have chunks. Now we need to have slightly different
-                # behaviours based on dimensions
+                # OK, we have chunks, lets use them to make sure we don't load
+                # too much into memory. Now we need to have slightly
+                # different behaviours based on dimensions
 
-                # For 1D arrays we can just loop getting the sum.
-                if self.ndim == 1:
-                    # Define the sum
-                    val_sum = 0
+                # Define initial sum
+                val_sum = 0
 
-                    # Compute the number of chunks in each dimension
-                    n_chunks = int(self.shape[0] / self.chunks[0])
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="Mean"
-                    ) as pb:
-                        for chunk_index in range(n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                [
-                                    slice(
-                                        chunk_index * self.chunks[0],
-                                        min(
-                                            (chunk_index + 1) * self.chunks[0],
-                                            self.shape[0],
-                                        ),
-                                    ),
-                                ]
+                # Loop over all possible chunks
+                with ProgressBar(total=self.size, description="Mean") as pb:
+                    for chunk_index in np.ndindex(*self.n_chunks):
+                        # Get the current slice for each dimension
+                        slices = tuple(
+                            slice(
+                                c_idx * c_size,
+                                min((c_idx + 1) * c_size, s),
                             )
-
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
-
-                            # Add this chunk
-                            val_sum += np.sum(chunk_data)
-
-                            pb.advance(step=chunk_data.size)
-
-                    # Return the mean
-                    return val_sum / self.size
-
-                # Otherwise we get the mean for the final
-                # dimension
-                else:
-                    # Define initial sum
-                    val_sum = np.zeros(self.shape[-1])
-
-                    # Compute the number of chunks in each dimension
-                    n_chunks = [
-                        int(np.ceil(s / c))
-                        for s, c in zip(self.shape, self.chunks)
-                    ]
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="Mean"
-                    ) as pb:
-                        for chunk_index in np.ndindex(*n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                slice(
-                                    c_idx * c_size,
-                                    min((c_idx + 1) * c_size, s),
-                                )
-                                for c_idx, c_size, s in zip(
-                                    chunk_index, self.chunks, self.shape
-                                )
+                            for c_idx, c_size, s in zip(
+                                chunk_index, self.chunks, self.shape
                             )
+                        )
 
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
+                        # Read the chunk data
+                        chunk_data = dataset[slices]
 
-                            # Get the sum for the final dimension
-                            val_sum += np.sum(
-                                chunk_data,
-                                axis=tuple(range(self.ndim - 1)),
-                            )
+                        # Get the sum
+                        val_sum += np.sum(
+                            chunk_data,
+                        )
 
-                            pb.advance(step=chunk_data.size)
+                        pb.advance(step=chunk_data.size)
 
-                    # Return the mean
-                    return val_sum / (self.size / self.shape[-1])
+                # Return the mean
+                return val_sum / (self.size)
 
     def get_std(self):
         """
         Return the standard deviation of the dataset values.
 
-        NOTE: this will first calculate the mean so requires two loops over
-        the chunks and thus two progress bars will be displayed.
+        This will calculate the global standard deviation of the dataset,
+        ignoring any axes.
 
-        To limit the memory load this will use the chunks recorded in the
-        dataset to read in the data in manageable chunks and compute the
-        mean value on the fly. If chunks == shape then
-        the mean is calculated on the whole Dataset.
+        If the dataset is chunked we will use them to limit the memory load
+        and read in the data in manageable chunks and compute the standard
+        deviation on the fly.
 
         Returns:
             float:
@@ -642,92 +542,39 @@ class Node:
                 # If chunks and shape are equal just get the min and max
                 if not self.is_chunked:
                     arr = dataset[:]
-                    return arr.std(axis=0)
+                    return arr.std()
 
-                # OK, we have chunks. Now we need to have slightly different
-                # behaviours based on dimensions. This also means doing the
-                # mean first
+                # OK, we have chunks, lets use them to make sure we don't load
+                # too much into memory.
 
-                # First we need the mean
-                mean = self.get_mean()
+                # Define initial sum
+                val_sum = 0
+                spu_val_sum = 0
 
-                # For 1D arrays we can just loop getting the stardard deviation
-                if self.ndim == 1:
-                    # Define the sum
-                    val_sum = 0
-
-                    # Compute the number of chunks in each dimension
-                    n_chunks = int(self.shape[0] / self.chunks[0])
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="StDev"
-                    ) as pb:
-                        for chunk_index in range(n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                [
-                                    slice(
-                                        chunk_index * self.chunks[0],
-                                        min(
-                                            (chunk_index + 1) * self.chunks[0],
-                                            self.shape[0],
-                                        ),
-                                    ),
-                                ]
+                # Loop over all possible chunks
+                with ProgressBar(total=self.size, description="StDev") as pb:
+                    for chunk_index in np.ndindex(*self.n_chunks):
+                        # Get the current slice for each dimension
+                        slices = tuple(
+                            slice(
+                                c_idx * c_size,
+                                min((c_idx + 1) * c_size, s),
                             )
-
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
-
-                            # Add this chunk
-                            val_sum += np.sum((chunk_data - mean) ** 2)
-
-                            pb.advance(step=chunk_data.size)
-
-                    # Return the standard deviation
-                    return np.sqrt(val_sum / (self.size - 1))
-
-                # Otherwise we get the standard deviation for the final
-                # dimension
-                else:
-                    # Define initial sum
-                    val_sum = np.zeros(self.shape[-1])
-
-                    # Compute the number of chunks in each dimension
-                    n_chunks = [
-                        int(np.ceil(s / c))
-                        for s, c in zip(self.shape, self.chunks)
-                    ]
-
-                    # Loop over all possible chunks
-                    with ProgressBar(
-                        total=self.size, description="StDev"
-                    ) as pb:
-                        for chunk_index in np.ndindex(*n_chunks):
-                            # Get the current slice for each dimension
-                            slices = tuple(
-                                slice(
-                                    c_idx * c_size,
-                                    min((c_idx + 1) * c_size, s),
-                                )
-                                for c_idx, c_size, s in zip(
-                                    chunk_index, self.chunks, self.shape
-                                )
+                            for c_idx, c_size, s in zip(
+                                chunk_index, self.chunks, self.shape
                             )
+                        )
 
-                            # Read the chunk data
-                            chunk_data = dataset[slices]
+                        # Read the chunk data
+                        chunk_data = dataset[slices]
 
-                            # Get the sum for the final dimension
-                            val_sum += np.sum(
-                                (chunk_data - mean) ** 2,
-                                axis=tuple(range(self.ndim - 1)),
-                            )
+                        # Get the sum and sum of squares
+                        val_sum += np.sum(chunk_data)
+                        spu_val_sum += np.sum(chunk_data**2)
 
-                            pb.advance(step=chunk_data.size)
+                        pb.advance(step=chunk_data.size)
 
-                    # Return the standard deviation
-                    return np.sqrt(
-                        val_sum / ((self.size / self.shape[-1]) - 1)
-                    )
+                # Return the standard deviation
+                return np.sqrt(
+                    (spu_val_sum / self.size) - (val_sum / self.size) ** 2
+                )

--- a/src/h5forest/node.py
+++ b/src/h5forest/node.py
@@ -15,6 +15,7 @@ Example usage:
     print(node.is_expanded)
 
 """
+
 import h5py
 import numpy as np
 
@@ -413,7 +414,7 @@ class Node:
                 # If chunks and shape are equal just get the min and max
                 if not self.is_chunked:
                     arr = dataset[:]
-                    return arr.min(axis=0), arr.max(axis=0)
+                    return arr.min(), arr.max()
 
                 # OK, we have chunks. Now we need to have slightly different
                 # behaviours based on dimensions
@@ -448,7 +449,8 @@ class Node:
                             # Read the chunk data
                             chunk_data = dataset[slices]
 
-                            # Get the minimum and maximum for the final dimension
+                            # Get the minimum and maximum for the final
+                            # dimension
                             min_val = np.min((min_val, np.min(chunk_data)))
                             max_val = np.max((max_val, np.max(chunk_data)))
 
@@ -488,7 +490,8 @@ class Node:
                             # Read the chunk data
                             chunk_data = dataset[slices]
 
-                            # Get the minimum and maximum for the final dimension
+                            # Get the minimum and maximum for the final
+                            # dimension
                             min_val = np.minimum(
                                 min_val,
                                 np.min(

--- a/src/h5forest/plotting.py
+++ b/src/h5forest/plotting.py
@@ -244,8 +244,8 @@ class DensityPlotter(Plotter):
         """
         Set the weights-axis key for the plot.
 
-        This will set the plot parameter for the weights-axis key and update the
-        plotting text.
+        This will set the plot parameter for the weights-axis key and update
+        the plotting text.
 
         Args:
             node (h5forest.h5_forest.Node):
@@ -333,7 +333,9 @@ class DensityPlotter(Plotter):
         chunk_shape = min((x_node.chunks[0], y_node.chunks[0]))
 
         # Get the number of chunks
-        chunks = x_node.shape[0] // chunk_shape if chunk_shape is not None else 1
+        chunks = (
+            x_node.shape[0] // chunk_shape if chunk_shape is not None else 1
+        )
 
         # If neither node is not chunked we can just read and grid the data
         if chunks == 1:
@@ -365,7 +367,9 @@ class DensityPlotter(Plotter):
                 x_shape = x_data.shape[0]
 
                 # Loop over the chunks
-                with ProgressBar(total=x_node.size, description="2DHist") as pb:
+                with ProgressBar(
+                    total=x_node.size, description="2DHist"
+                ) as pb:
                     for i in range(chunks):
                         # Define the slice
                         _slice = slice(
@@ -476,7 +480,9 @@ class DensityPlotter(Plotter):
                 x_shape = x_data.shape[0]
 
                 # Loop over the chunks
-                with ProgressBar(total=x_node.size, description="2DHist") as pb:
+                with ProgressBar(
+                    total=x_node.size, description="2DHist"
+                ) as pb:
                     for i in range(chunks):
                         # Define the slice
                         _slice = slice(
@@ -744,7 +750,9 @@ class HistogramPlotter(Plotter):
 
         # Define the bins
         if x_scale == "log":
-            bins = np.logspace(np.log10(self.x_min), np.log10(self.x_max), nbins + 1)
+            bins = np.logspace(
+                np.log10(self.x_min), np.log10(self.x_max), nbins + 1
+            )
         else:
             bins = np.linspace(self.x_min, self.x_max, nbins + 1)
         self.widths = bins[1:] - bins[:-1]
@@ -769,7 +777,9 @@ class HistogramPlotter(Plotter):
             self.hist = np.zeros(nbins)
 
             # Compute the number of chunks in each dimension
-            n_chunks = [int(np.ceil(s / c)) for s, c in zip(node.shape, node.chunks)]
+            n_chunks = [
+                int(np.ceil(s / c)) for s, c in zip(node.shape, node.chunks)
+            ]
 
             # Get the data
             with h5py.File(node.filepath, "r") as hdf:

--- a/src/h5forest/progress.py
+++ b/src/h5forest/progress.py
@@ -11,6 +11,7 @@ Example usage:
         for i in range(100):
             bar.advance()
 """
+
 from h5forest.utils import get_window_size
 
 

--- a/src/h5forest/tree.py
+++ b/src/h5forest/tree.py
@@ -9,6 +9,7 @@ Example usage:
     tree = Tree("example.h5")
     print(tree.get_tree_text())
 """
+
 import h5py
 
 from h5forest.node import Node
@@ -184,9 +185,9 @@ class Tree:
 
         # Insert the children into the tree text and nodes by row list
         self.tree_text_split[current_row + 1 : current_row + 1] = child_test
-        self.nodes_by_row[
-            current_row + 1 : current_row + 1
-        ] = child_nodes_by_row
+        self.nodes_by_row[current_row + 1 : current_row + 1] = (
+            child_nodes_by_row
+        )
 
         # Update the tree text area
         self.tree_text = "\n".join(self.tree_text_split)

--- a/src/h5forest/utils.py
+++ b/src/h5forest/utils.py
@@ -1,4 +1,5 @@
 """A module containing utility functions and classes for the HDF5 viewer."""
+
 import os
 
 


### PR DESCRIPTION
Now the Dataset statistics behave better (i.e. more predictably). Previously they assumed the stats should be computed over the first axis but this leads to unreadable outputs in the mini-buffer for most situations. 

Now global statistic computed over all axis is shown and returned.

This also introduces proper formatting with `ruff`