### PR TITLE
Reorganising the layout of panes

### DIFF
--- a/src/h5forest/bindings/bindings.py
+++ b/src/h5forest/bindings/bindings.py
@@ -7,6 +7,7 @@ application.
 """
 
 from prompt_toolkit.filters import Condition
+from prompt_toolkit.layout import ConditionalContainer
 from prompt_toolkit.widgets import Label
 
 
@@ -54,6 +55,16 @@ def _init_app_bindings(app):
         app.default_focus()
         event.app.invalidate()
 
+    def expand_attributes(event):
+        """Expand the attributes."""
+        app.flag_expanded_attrs = True
+        event.app.invalidate()
+
+    def collapse_attributes(event):
+        """Collapse the attributes."""
+        app.flag_expanded_attrs = False
+        event.app.invalidate()
+
     # Bind the functions
     app.kb.add("q", filter=Condition(lambda: app.flag_normal_mode))(exit_app)
     app.kb.add("c-q")(exit_app)
@@ -75,9 +86,29 @@ def _init_app_bindings(app):
     app.kb.add("q", filter=Condition(lambda: not app.flag_normal_mode))(
         exit_leader_mode
     )
+    app.kb.add(
+        "A",
+        filter=Condition(
+            lambda: app.flag_normal_mode and not app.flag_expanded_attrs
+        ),
+    )(expand_attributes)
+    app.kb.add(
+        "A",
+        filter=Condition(
+            lambda: app.flag_normal_mode and app.flag_expanded_attrs
+        ),
+    )(collapse_attributes)
 
     # Add the hot keys
     hot_keys = [
+        ConditionalContainer(
+            Label("A → Expand Attributes"),
+            filter=Condition(lambda: not app.flag_expanded_attrs),
+        ),
+        ConditionalContainer(
+            Label("A → Shrink Attributes"),
+            filter=Condition(lambda: app.flag_expanded_attrs),
+        ),
         Label("d → Dataset Mode"),
         Label("h → Hist Mode"),
         Label("j → Jump Mode"),

--- a/src/h5forest/h5_forest.py
+++ b/src/h5forest/h5_forest.py
@@ -145,6 +145,7 @@ class H5Forest:
         # Define flags we need to control behaviour
         self.flag_values_visible = False
         self.flag_progress_bar = False
+        self.flag_expanded_attrs = False
 
         # Define the leader key mode flags
         # NOTE: These must be unset when the leader mode is exited, and in
@@ -518,6 +519,8 @@ class H5Forest:
                 return columns // 2
             elif self.flag_hist_mode or len(self.histogram_plotter) > 0:
                 return columns // 2
+            elif self.flag_expanded_attrs:
+                return columns // 2
             else:
                 return columns
 
@@ -536,12 +539,23 @@ class H5Forest:
             self.metadata_content,
             title="Metadata",
             height=10,
-            width=columns // 2,
         )
-        self.attrs_frame = Frame(
-            self.attributes_content,
-            title="Attributes",
-            height=10,
+        self.attrs_frame = ConditionalContainer(
+            Frame(
+                self.attributes_content,
+                title="Attributes",
+                height=10,
+                width=columns // 2,
+            ),
+            filter=Condition(lambda: not self.flag_expanded_attrs),
+        )
+        self.expanded_attrs_frame = ConditionalContainer(
+            Frame(
+                self.attributes_content,
+                title="Attributes",
+                width=columns // 2,
+            ),
+            filter=Condition(lambda: self.flag_expanded_attrs),
         )
 
         # Set up the values frame (this is where we'll display the values of
@@ -652,6 +666,7 @@ class H5Forest:
                             self.tree_frame,
                             HSplit(
                                 [
+                                    self.expanded_attrs_frame,
                                     self.values_frame,
                                     self.plot_frame,
                                     self.hist_frame,


### PR DESCRIPTION
The attribute pane rarely needs to be the height of the window. This is now down the bottom but can be expanded with `<A>` back to the old full-height version. 

Mouse support is also enabled for focusable windows. 