### PR TITLE
Fixed mouse highlight

### DIFF
--- a/src/h5forest/h5_forest.py
+++ b/src/h5forest/h5_forest.py
@@ -214,7 +214,7 @@ class H5Forest:
             layout=self.layout,
             key_bindings=self.kb,
             full_screen=True,
-            mouse_support=True,
+            mouse_support=False,
             style=style,
         )
 


### PR DESCRIPTION
The last update set `mouse_support=True` in anticipation of doing more with mouse interaction. The unintended consequence of this is that `prompt_toolkit` intercepts all mouse interaction, making highlight and copy impossible. Highlighting is far more valuable than clicking to select windows so this PR turns off mouse support (stopping `prompt_toolkit` from intercepting mouse interaction.